### PR TITLE
Make repo owner configurable

### DIFF
--- a/src/main/kotlin/net/civmc/civgradle/CivGradleExtension.kt
+++ b/src/main/kotlin/net/civmc/civgradle/CivGradleExtension.kt
@@ -7,6 +7,7 @@ import javax.inject.Inject
 
 open class CivGradleExtension @Inject constructor(objects: ObjectFactory) {
 
+    var repoOwner = "CivMC"
     var pluginName = ""
 
     val paper: PlatformPaperExtension = objects.newInstance(PlatformPaperExtension::class.java)

--- a/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
+++ b/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
@@ -73,7 +73,7 @@ object PlatformCommon {
             if (!githubActor.isNullOrEmpty() && !githubToken.isNullOrEmpty()) {
                 it.maven {
                     it.name = "GitHubPackages"
-                    it.url = URI("https://maven.pkg.github.com/CivMC/${extension.pluginName}")
+                    it.url = URI("https://maven.pkg.github.com/${extension.repoOwner}/${extension.pluginName}")
                     it.credentials {
                         it.username = githubActor
                         it.password = githubToken


### PR DESCRIPTION
Currently the `url` property that is set in `configureMavenPublish` is hardcoded to the CivMC repos. This change will default to the CivMC repos but allow publishing to other repos too.