### PR TITLE
Add Maven-esque test logging

### DIFF
--- a/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
+++ b/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
@@ -63,7 +63,7 @@ object PlatformCommon {
         project.tasks.withType(Test::class.java) { testing ->
             testing.useJUnitPlatform()
             testing.testLogging { logging ->
-                logging.events(TestLogEvent.values())
+                logging.events(*TestLogEvent.values())
                 logging.exceptionFormat = TestExceptionFormat.FULL
                 logging.showCauses = true
                 logging.showExceptions = true

--- a/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
+++ b/src/main/kotlin/net/civmc/civgradle/common/PlatformCommon.kt
@@ -7,6 +7,9 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.slf4j.Logger
@@ -55,6 +58,17 @@ object PlatformCommon {
 
         project.tasks.withType(ProcessResources::class.java) {
             it.filteringCharset = Charsets.UTF_8.name()
+        }
+
+        project.tasks.withType(Test::class.java) { testing ->
+            testing.useJUnitPlatform()
+            testing.testLogging { logging ->
+                logging.events(TestLogEvent.values())
+                logging.exceptionFormat = TestExceptionFormat.FULL
+                logging.showCauses = true
+                logging.showExceptions = true
+                logging.showStackTraces = true
+            }
         }
 
         logger.debug("Java tasks configured")


### PR DESCRIPTION
This will standardise an improved test output. Here is CivModCore's test output with these settings:

```
> Task :CivModCore:test

ConfigTests > pseudoConfigTest() PASSED

InheritanceTests > testStaticInheritance() PASSED

ItemMetaTests STANDARD_OUT
    2023-05-25 20:17:46,749 Test worker WARN Advanced terminal features are not available in this environment

ItemMetaTests > testBaseComponent() PASSED

ItemMetaTests > testAdvancedDisplayNameEquality() PASSED

NBTTests > testStringArraySerialization() PASSED

NBTTests > testNBTClearing() PASSED

NBTTests > testMapDeserialisation() PASSED

NBTTests > testNullSerialization() PASSED

NBTTests > testItemStackSerialisation() PASSED

NBTTests > testByteSerialization() PASSED

NBTTests > testLocationSerialisation() PASSED

NBTTests > testStringSerialization() PASSED

TextTests > testComponentOrderEquality() PASSED

TextTests > testComponentArrangementEquality() PASSED

UuidTests > testUuidSerialization() PASSED
```